### PR TITLE
Hot-swap peers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import fs from 'bare-fs';
 import path from 'bare-path';
+import process from 'bare-process';
 import Hyperswarm from 'hyperswarm';
 import Hyperdrive from 'hyperdrive';
 import Localdrive from 'localdrive';
@@ -61,6 +62,13 @@ async function main() {
     const keyPair = await parseKeyPairFromEnv();
     const peersDirectoryPath = path.join('data', 'peers');
     const peers = await parsePeers(peersDirectoryPath);
+    setInterval(async () => {
+        const currentPeers = await parsePeers(peersDirectoryPath);
+        if (peers.map(peer => `${peer.alias}-${peer.publicKey}`).sort().toString() !== currentPeers.map(peer => `${peer.alias}-${peer.publicKey}`).sort().toString()) {
+            console.log('Peers have changed. Exiting to allow restart.');
+            process.exit(0);
+        }
+    }, 60000);
 
     console.log('Preparing to connect...');
     // Create 2 Corestore instances per peer in a local directory


### PR DESCRIPTION
Closes https://github.com/bbenligiray/hinter-core/issues/23

Considering that peer changes should be fairly infrequent, this feels to be the best implementation. Obviously it is assumed that the app runs in a container that always restarts, otherwise this just closes the app for it to be restarted manually or some other way.