### PR TITLE
Replace the --local argument back with --data-dir

### DIFF
--- a/.changeset/tidy-boxes-pick.md
+++ b/.changeset/tidy-boxes-pick.md
@@ -2,4 +2,4 @@
 "@hinter-net/hinter-core": minor
 ---
 
-hinter-core-data/ is expected to be in the home directory by default, and in the current directory if the --local/-l argument is used
+hinter-core-data/ is expected to be in the home directory by default, and in a specific directory if the --data-dir argument is used.

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,13 +27,13 @@ jobs:
 
       - name: Setup hinter1
         run: |
-          hinter-core-initialize --local
+          hinter-core-initialize --data-dir $(pwd)/hinter-core-data
           mkdir -p hinter-core-data/peers/hinter2/outgoing
           mkdir -p hinter-core-data/peers/hinter2/incoming
           echo "{\"publicKey\":\"9e230ac8b403f3861871c2325f3226c930e7e4f0809b6633a6870aa05904ef01\"}" > hinter-core-data/peers/hinter2/hinter.config.json
 
       - name: Run hinter-core in background
-        run: pm2 start hinter-core --name hinter1 -- --local
+        run: pm2 start hinter-core --name hinter1 -- --data-dir $(pwd)/hinter-core-data
 
       - name: Wait for instance to be ready
         run: sleep 10
@@ -92,13 +92,13 @@ jobs:
 
       - name: Setup hinter2
         run: |
-          hinter-core-initialize --local
+          hinter-core-initialize --data-dir $(pwd)/hinter-core-data
           mkdir -p hinter-core-data/peers/hinter1/outgoing
           mkdir -p hinter-core-data/peers/hinter1/incoming
           echo "{\"publicKey\":\"1720090ca74ba7c5100c5c9bf7898171fbae0ede675fa7c3aa248bd1d6c96a8f\"}" > hinter-core-data/peers/hinter1/hinter.config.json
 
       - name: Run hinter-core in background
-        run: pm2 start hinter-core --name hinter2 -- --local
+        run: pm2 start hinter-core --name hinter2 -- --data-dir $(pwd)/hinter-core-data
 
       - name: Wait for instance to be ready
         run: sleep 10

--- a/README.md
+++ b/README.md
@@ -34,13 +34,17 @@ This will create a `hinter-core-data` directory in your user's home folder (`~/h
 hinter-core-initialize
 ```
 
-**Local (in the current directory):**
+**Custom Location:**
 
-This will create a `hinter-core-data` directory inside the folder you are currently in.
-This is useful for running multiple instances.
+You can specify a custom location for your data directory.
+This is the recommended way to run multiple instances.
 
 ```bash
-hinter-core-initialize --local
+# For a local directory (will create ./my-hinter-core-data)
+hinter-core-initialize --data-dir $(pwd)/my-hinter-core-data
+
+# For any other directory
+hinter-core-initialize --data-dir /path/to/my-hinter-core-data
 ```
 
 ### Running the Service
@@ -53,16 +57,21 @@ To run `hinter-core` as a background service and ensure it restarts automaticall
 pm2 start hinter-core --name my-hinter-core
 ```
 
-**Local Instance:**
+**Custom Instance:**
 
-Make sure you are in the same directory where you ran the `hinter-core-initialize --local` command.
+To run an instance with a custom data directory, pass the `--data-dir` argument.
+Using an absolute path is required to ensure `pm2` can find the directory after a system reboot.
 
 ```bash
-pm2 start hinter-core --name my-hinter-core -- --local
+# For the local directory created above
+pm2 start hinter-core --name my-hinter-core -- --data-dir $(pwd)/my-hinter-core-data
+
+# For any other directory
+pm2 start hinter-core --name my-other-hinter-core -- --data-dir /path/to/my-hinter-core-data
 ```
 
 > **Note:** The `--` is important.
-It tells `pm2` to stop parsing arguments for itself and pass the remaining arguments (in this case, `--local`) directly to the `hinter-core` application.
+It tells `pm2` to stop parsing arguments for itself and pass the remaining arguments (in this case, `--data-dir ...`) directly to the `hinter-core` application.
 
 ### Enabling Auto-Restart on System Reboot
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,8 +5,13 @@ import hypercoreCrypto from 'hypercore-crypto';
 import b4a from 'b4a';
 
 export function getDataDir() {
-    if (process.argv.includes('--local') || process.argv.includes('-l')) {
-        return path.join(process.cwd(), 'hinter-core-data');
+    const dataDirIndex = process.argv.indexOf('--data-dir');
+    if (dataDirIndex !== -1 && process.argv.length > dataDirIndex + 1) {
+        const dataDir = process.argv[dataDirIndex + 1];
+        if (!path.isAbsolute(dataDir)) {
+            throw new Error('The --data-dir path must be an absolute path.');
+        }
+        return dataDir;
     }
     return path.join(os.homedir(), 'hinter-core-data');
 }


### PR DESCRIPTION
The reasoning is that a hinter-core run in always restart mode with the --local argument will not be able to find the hinter-core-data/ path after the restart. Therefore, parameterized hinter-core-data/ paths have to be absolute.