### PR TITLE
Use a single Corestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 node_modules
+.DS_Store
 
 .storage
 hinter-core-data
+fuzz
 .env
+
+.idea
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 .DS_Store
 
 .storage
-hinter-core-data
+hinter-core-data*
 fuzz
 .env
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "bracketSpacing": true,
+  "printWidth": 120,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "parser": "markdown",
+        "proseWrap": "always"
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,29 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
+        "@api3/promise-utils": "^0.4.0",
         "b4a": "^1.6.7",
         "chokidar": "^4.0.3",
         "corestore": "^7.4.5",
         "hyperdrive": "^12.3.0",
         "hyperswarm": "^4.11.7",
-        "localdrive": "^2.2.0"
+        "localdrive": "^2.2.0",
+        "lodash": "^4.17.21"
       },
       "bin": {
         "hinter-core": "src/index.js",
         "hinter-core-initialize": "src/initialize.js"
       },
       "devDependencies": {
-        "@changesets/cli": "^2.29.5"
+        "@changesets/cli": "^2.29.5",
+        "prettier": "^3.6.2"
       }
+    },
+    "node_modules/@api3/promise-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@api3/promise-utils/-/promise-utils-0.4.0.tgz",
+      "integrity": "sha512-+8fcNjjQeQAuuSXFwu8PMZcYzjwjDiGYcMUfAQ0lpREb1zHonwWZ2N0B9h/g1cvWzg9YhElbeb/SyhCrNm+b/A==",
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.2",
@@ -54,6 +63,22 @@
         "prettier": "^2.7.1",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
@@ -275,6 +300,22 @@
         "fs-extra": "^7.0.1",
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@hyperswarm/secret-stream": {
@@ -1382,6 +1423,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
@@ -1627,16 +1674,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,17 @@
     "start": "node src/index.js --data-dir $(pwd)/hinter-core-data"
   },
   "dependencies": {
+    "@api3/promise-utils": "^0.4.0",
     "b4a": "^1.6.7",
     "chokidar": "^4.0.3",
     "corestore": "^7.4.5",
     "hyperdrive": "^12.3.0",
     "hyperswarm": "^4.11.7",
-    "localdrive": "^2.2.0"
+    "localdrive": "^2.2.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.29.5"
+    "@changesets/cli": "^2.29.5",
+    "prettier": "^3.6.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,15 @@ import b4a from 'b4a';
 import chokidar from 'chokidar';
 import lodash from 'lodash';
 import { goSync } from '@api3/promise-utils';
-import { printAsciiArt, parseEnvFile, getDataDir, getPeersDir, deriveKeyExchangeTopic } from './utils.js';
+import {
+  deriveKeyExchangeTopic,
+  getDataDir,
+  getPeersDir,
+  logError,
+  logInfo,
+  parseEnvFile,
+  printAsciiArt,
+} from './utils.js';
 import { checkPeerSizeLimit, parsePeersAndMonitorForChanges } from './peer.js';
 import { parseGlobalConfig } from './config.js';
 
@@ -23,14 +31,14 @@ async function main() {
   const { keyPair } = await parseEnvFile();
   const globalConfig = parseGlobalConfig();
   const peersDirectoryPath = getPeersDir(dataDir);
-  console.log('Parsing peers...');
+  logInfo('Parsing peers...');
   const peerConfigs = parsePeersAndMonitorForChanges(peersDirectoryPath, globalConfig, () => {
-    console.log('Peers have changed. Exiting to allow restart.');
+    logInfo('Peers have changed. Exiting to allow restart.');
     process.exit(0);
   });
-  console.log(`Parsed ${peerConfigs.length} peer(s)!`);
+  logInfo(`Parsed ${peerConfigs.length} peer(s)!`);
 
-  console.log('Preparing to connect...');
+  logInfo('Preparing to connect...');
   const storageDir = path.join(dataDir, '.storage');
   const store = new Corestore(storageDir);
   await store.ready();
@@ -39,9 +47,9 @@ async function main() {
   const swarm = new Hyperswarm({ keyPair });
 
   const cleanup = async () => {
-    console.log('Closing swarm...');
+    logInfo('Closing swarm...');
     await swarm.destroy();
-    console.log('Closed swarm.');
+    logInfo('Closed swarm.');
     process.exit(0);
   };
 
@@ -57,7 +65,6 @@ async function main() {
       const outgoingHyperdrive = new Hyperdrive(outgoingNamespace);
       await outgoingHyperdrive.ready();
 
-      console.log(`[${peerConfig.alias}] Outgoing drive key: ${outgoingHyperdrive.key.toString('hex')}`);
       return {
         ...peerConfig,
         outgoingHyperdrive,
@@ -73,38 +80,39 @@ async function main() {
     const peerPublicKey = Buffer.from(peerInfo.publicKey).toString('hex');
     const peer = peers.find((p) => p.publicKey === peerPublicKey);
     if (!peer) {
-      console.error(`Unknown peer with public key ${peerPublicKey}`);
+      logError(`Unknown peer with public key ${peerPublicKey}`);
       conn.end();
       return;
     }
 
     const stream = store.replicate(conn);
     stream.on('error', (err) => handleReplicationError(peer, err));
-    console.log(`Connected to ${peer.alias}!`);
+    logInfo(`Connected to ${peer.alias}!`);
 
+    // Exchange drive keys
     conn.on('data', (buffer) => handleReceiveDriveKeyFromPeer(peer, buffer));
-    console.log(`Sending drive key to ${peer.alias}`);
     const message = {
       type: 'share-drive-key',
       outgoingHyperdriveKeyHex: peer.outgoingHyperdrive.key.toString('hex'),
     };
     conn.write(JSON.stringify(message), 'utf8');
+    logInfo(`Sent drive key to ${peer.alias}`);
   });
 
   function handleReplicationError(peer, err) {
     if (err.message.includes('connection reset by peer') || err.message.includes('connection timed out')) {
-      console.log(`${peer.alias} disconnected.`);
+      logInfo(`[${peer.alias}] Disconnected`);
       return;
     }
     if (err.message.includes('Duplicate connection')) {
-      console.log(`${peer.alias} connection duplicated.`);
+      logInfo(`[${peer.alias}] Connection duplicated`);
       return;
     }
 
     const errorMessage = `${peer.alias} replication error: ${err.message}`;
     console.error(errorMessage);
     fs.writeFileSync(path.join(peersDirectoryPath, peer.alias, '.blacklisted'), errorMessage);
-    console.log(`Blacklisted ${peer.alias} due to replication error. Exiting for restart.`);
+    logInfo(`Blacklisted ${peer.alias} due to replication error. Exiting for restart.`);
     process.exit(0);
   }
 
@@ -118,15 +126,15 @@ async function main() {
       return;
     }
 
-    console.log(`Received drive key exchange message from ${peer.alias}:`, result.data);
+    logInfo(`Received drive key from ${peer.alias}`);
     if (peer.incomingHyperdriveKeyHex) {
       // If a peer deletes their .storage directory they will create a new outgoing Hyperdrive the next time their
       // hinter-core starts up. When that happens it's easier to just restart in order to mirror their new drive.
       if (peer.incomingHyperdriveKeyHex !== result.data.outgoingHyperdriveKeyHex) {
-        console.log(`${peer.alias} has a new outgoing Hyperdrive. Exiting for restart.`);
+        logInfo(`${peer.alias} has a new outgoing Hyperdrive. Exiting for restart.`);
         process.exit(0);
       }
-      console.log(`[${peer.alias}] Already setup`);
+      logInfo(`[${peer.alias}] Already setup`);
       return;
     }
 
@@ -140,25 +148,24 @@ async function main() {
   await Promise.all(
     peers.map(async (peer) => {
       const keyExchangeTopic = deriveKeyExchangeTopic(keyPair.publicKey.toString('hex'), peer.publicKey);
-      console.log(`[${peer.alias}] Joining key exchange: ${keyExchangeTopic.toString('hex')}`);
+      logInfo(`Joining key exchange topic for ${peer.alias}: ${keyExchangeTopic.toString('hex')}`);
       const discovery = swarm.join(keyExchangeTopic, { client: true, server: true });
       await discovery.flushed();
-      console.log(`[${peer.alias}] Joined key exchange`);
     })
   );
 
   async function completeHyperdriveSetup(peer, incomingDriveKeyHex) {
-    console.log(`[${peer.alias}] Setting up drives with incoming drive key: ${incomingDriveKeyHex}`);
+    logInfo(`[${peer.alias}] Setting up drives with incoming drive key: ${incomingDriveKeyHex}`);
 
     const outgoingDiscovery = swarm.join(peer.outgoingHyperdrive.discoveryKey, { client: false, server: true });
     await outgoingDiscovery.flushed();
 
     const outgoingLocaldrive = new Localdrive(path.join(peersDirectoryPath, peer.alias, 'outgoing'));
     async function mirrorOutgoing() {
-      console.log(`[${peer.alias}] OUT: Mirroring outgoing drive`);
+      logInfo(`[${peer.alias}] Mirroring outgoing drive...`);
       const outgoingMirror = outgoingLocaldrive.mirror(peer.outgoingHyperdrive);
       await outgoingMirror.done();
-      console.log(`[${peer.alias}] OUT: Successfully mirrored outgoing drive`);
+      logInfo(`[${peer.alias}] Successfully mirrored outgoing drive`);
     }
 
     const debouncedMirrorOutgoing = debounce(mirrorOutgoing, 1000);
@@ -173,13 +180,13 @@ async function main() {
         },
       })
       .on('all', async () => {
-        console.log(`OUT: Detected change in local outgoing directory for ${peer.alias}`);
+        logInfo(`[${peer.alias}] Detected change in local outgoing directory`);
         debouncedMirrorOutgoing();
       });
     debouncedMirrorOutgoing();
 
     if (peer.disableIncomingReports) {
-      console.log(`[${peer.alias}] Incoming reports are disabled`);
+      logInfo(`[${peer.alias}] Incoming reports are disabled`);
       return;
     }
 
@@ -191,19 +198,18 @@ async function main() {
 
     const incomingLocaldrive = new Localdrive(path.join(peersDirectoryPath, peer.alias, 'incoming'));
     async function mirrorIncoming() {
-      console.log(`[${peer.alias}] IN: Mirroring incoming drive`);
+      logInfo(`[${peer.alias}] Mirroring incoming drive...`);
       const incomingMirror = incomingHyperdrive.mirror(incomingLocaldrive);
       await incomingMirror.done();
-      console.log(`[${peer.alias}] IN: Successfully mirrored incoming drive`);
+      logInfo(`[${peer.alias}] Successfully mirrored incoming drive`);
 
-      console.log(`[${peer.alias}] Calculating incoming drive size`);
       const size = await checkPeerSizeLimit(peer, incomingHyperdrive);
-      console.log(`[${peer.alias}] Calculated incoming drive size: ${size / 1024 / 1024}MB (${size})`);
+      logInfo(`[${peer.alias}] Incoming drive size: ${(size / 1024 / 1024).toFixed(3)} MB (${size} bytes)`);
     }
 
     const debouncedMirrorIncoming = debounce(mirrorIncoming, 1000);
     incomingHyperdrive.core.on('append', () => {
-      console.log(`[${peer.alias}] IN: Detected change in incoming drive`);
+      logInfo(`[${peer.alias}] Detected change in incoming drive`);
       debouncedMirrorIncoming();
     });
     // Mirror when changes are detected in incoming localdrive
@@ -217,13 +223,13 @@ async function main() {
         },
       })
       .on('all', async () => {
-        console.log(`[${peer.alias}] IN: Detected change in local incoming directory`);
+        logInfo(`[${peer.alias}] Detected change in local incoming directory`);
         debouncedMirrorIncoming();
       });
     debouncedMirrorIncoming();
   }
 
-  console.log('Ready to connect all peers!');
+  logInfo('Ready to connect all peers!');
 }
 
 main();

--- a/src/index.js
+++ b/src/index.js
@@ -157,8 +157,6 @@ async function main() {
   );
 
   async function completeHyperdriveSetup(peer, incomingDriveKeyHex) {
-    logInfo(`[${peer.alias}] Setting up drives with incoming drive key: ${incomingDriveKeyHex}`);
-
     const outgoingDiscovery = swarm.join(peer.outgoingHyperdrive.discoveryKey, { client: false, server: true });
     await outgoingDiscovery.flushed();
 
@@ -181,7 +179,7 @@ async function main() {
           pollInterval: 100,
         },
       })
-      .on('all', async () => {
+      .on('all', () => {
         logInfo(`[${peer.alias}] Detected change in local outgoing directory`);
         debouncedMirrorOutgoing();
       });
@@ -224,7 +222,7 @@ async function main() {
           pollInterval: 100,
         },
       })
-      .on('all', async () => {
+      .on('all', () => {
         logInfo(`[${peer.alias}] Detected change in local incoming directory`);
         debouncedMirrorIncoming();
       });

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ import { parseGlobalConfig } from './config.js';
 
 const { debounce } = lodash;
 
+const KEY_EXCHANGE_MESSAGE_TYPE = 'hinter-core/share-drive-key';
+
 printAsciiArt();
 
 async function main() {
@@ -92,7 +94,7 @@ async function main() {
     // Exchange drive keys
     conn.on('data', (buffer) => handleReceiveDriveKeyFromPeer(peer, buffer));
     const message = {
-      type: 'share-drive-key',
+      type: KEY_EXCHANGE_MESSAGE_TYPE,
       outgoingHyperdriveKeyHex: peer.outgoingHyperdrive.key.toString('hex'),
     };
     conn.write(JSON.stringify(message), 'utf8');
@@ -122,7 +124,7 @@ async function main() {
       // We don't log anything because we expect the parsing to fail for all buffers except the key exchange message
       return;
     }
-    if (result.data?.type !== 'share-drive-key') {
+    if (result.data?.type !== KEY_EXCHANGE_MESSAGE_TYPE) {
       return;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import chokidar from 'chokidar';
 import lodash from 'lodash';
 import { goSync } from '@api3/promise-utils';
 import { printAsciiArt, parseEnvFile, getDataDir, getPeersDir, deriveKeyExchangeTopic } from './utils.js';
-import { checkPeerSizeLimit, parsePeers } from './peer.js';
+import { checkPeerSizeLimit, parsePeersAndMonitorForChanges } from './peer.js';
 import { parseGlobalConfig } from './config.js';
 
 const { debounce } = lodash;
@@ -24,27 +24,11 @@ async function main() {
   const globalConfig = parseGlobalConfig();
   const peersDirectoryPath = getPeersDir(dataDir);
   console.log('Parsing peers...');
-  const initialPeers = await parsePeers(peersDirectoryPath, globalConfig);
-  // Clone initialPeers to be able to add dynamic elements to it
-  const peers = structuredClone(initialPeers);
-  console.log(`Parsed ${initialPeers.length} peers!`);
-  setInterval(async () => {
-    const currentPeers = await parsePeers(peersDirectoryPath, globalConfig);
-    // This assumes parsePeers() returns an object that is fully serializable with JSON.stringify()
-    if (
-      initialPeers
-        .map((peer) => JSON.stringify(peer))
-        .sort()
-        .toString() !==
-      currentPeers
-        .map((peer) => JSON.stringify(peer))
-        .sort()
-        .toString()
-    ) {
-      console.log('Peers have changed. Exiting to allow restart.');
-      process.exit(0);
-    }
-  }, 60_000);
+  const peerConfigs = parsePeersAndMonitorForChanges(peersDirectoryPath, globalConfig, () => {
+    console.log('Peers have changed. Exiting to allow restart.');
+    process.exit(0);
+  });
+  console.log(`Parsed ${peerConfigs.length} peer(s)!`);
 
   console.log('Preparing to connect...');
   const storageDir = path.join(dataDir, '.storage');
@@ -67,28 +51,27 @@ async function main() {
   /*
    * Partially set up our outgoing hyperdrives so that we can exchange their drive keys with our peers
    */
-  const peerInfoMap = new Map();
-  await Promise.all(
-    peers.map(async (peer) => {
-      const outgoingNamespace = store.namespace(`outgoing:${peer.publicKey}`);
+  const peers = await Promise.all(
+    peerConfigs.map(async (peerConfig) => {
+      const outgoingNamespace = store.namespace(`outgoing:${peerConfig.publicKey}`);
       const outgoingHyperdrive = new Hyperdrive(outgoingNamespace);
       await outgoingHyperdrive.ready();
 
-      console.log(`[${peer.alias}] Outgoing drive key: ${outgoingHyperdrive.key.toString('hex')}`);
-      peerInfoMap.set(peer.publicKey, {
-        ...peer,
+      console.log(`[${peerConfig.alias}] Outgoing drive key: ${outgoingHyperdrive.key.toString('hex')}`);
+      return {
+        ...peerConfig,
         outgoingHyperdrive,
         incomingHyperdriveKeyHex: null,
-      });
+      };
     })
   );
 
   /*
-   * Establish peer connections
+   * Establish peer connections, and complete Hyperdrives setup for each peer (upon receiving their drive key)
    */
   swarm.on('connection', (conn, peerInfo) => {
     const peerPublicKey = Buffer.from(peerInfo.publicKey).toString('hex');
-    const peer = peerInfoMap.get(peerPublicKey);
+    const peer = peers.find((p) => p.publicKey === peerPublicKey);
     if (!peer) {
       console.error(`Unknown peer with public key ${peerPublicKey}`);
       conn.end();
@@ -178,7 +161,7 @@ async function main() {
       console.log(`[${peer.alias}] OUT: Successfully mirrored outgoing drive`);
     }
 
-    const deboucedMirrorOutgoing = debounce(mirrorOutgoing, 1000);
+    const debouncedMirrorOutgoing = debounce(mirrorOutgoing, 1000);
     // Mirror when changes are detected in outgoing localdrive
     chokidar
       .watch(path.join(peersDirectoryPath, peer.alias, 'outgoing'), {
@@ -190,11 +173,10 @@ async function main() {
         },
       })
       .on('all', async () => {
-        console.log(`OUT: Detected change in outgoing for ${peer.alias}`);
-        deboucedMirrorOutgoing();
+        console.log(`OUT: Detected change in local outgoing directory for ${peer.alias}`);
+        debouncedMirrorOutgoing();
       });
-
-    await mirrorOutgoing();
+    debouncedMirrorOutgoing();
 
     if (peer.disableIncomingReports) {
       console.log(`[${peer.alias}] Incoming reports are disabled`);
@@ -219,10 +201,10 @@ async function main() {
       console.log(`[${peer.alias}] Calculated incoming drive size: ${size / 1024 / 1024}MB (${size})`);
     }
 
-    const deboucedMirrorIncoming = debounce(mirrorIncoming, 1000);
+    const debouncedMirrorIncoming = debounce(mirrorIncoming, 1000);
     incomingHyperdrive.core.on('append', () => {
-      console.log(`[${peer.alias}] IN: Detected append`);
-      deboucedMirrorIncoming();
+      console.log(`[${peer.alias}] IN: Detected change in incoming drive`);
+      debouncedMirrorIncoming();
     });
     // Mirror when changes are detected in incoming localdrive
     chokidar
@@ -236,10 +218,9 @@ async function main() {
       })
       .on('all', async () => {
         console.log(`[${peer.alias}] IN: Detected change in local incoming directory`);
-        await deboucedMirrorIncoming();
+        debouncedMirrorIncoming();
       });
-
-    deboucedMirrorIncoming();
+    debouncedMirrorIncoming();
   }
 
   console.log('Ready to connect all peers!');

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ async function main() {
     }
 
     const errorMessage = `${peer.alias} replication error: ${err.message}`;
-    console.error(errorMessage);
+    logError(errorMessage);
     fs.writeFileSync(path.join(peersDirectoryPath, peer.alias, '.blacklisted'), errorMessage);
     logInfo(`Blacklisted ${peer.alias} due to replication error. Exiting for restart.`);
     process.exit(0);
@@ -178,7 +178,7 @@ async function main() {
         ignoreInitial: true,
         awaitWriteFinish: {
           stabilityThreshold: 2000,
-          pollInterval: 1000,
+          pollInterval: 100,
         },
       })
       .on('all', async () => {
@@ -221,7 +221,7 @@ async function main() {
         ignoreInitial: true,
         awaitWriteFinish: {
           stabilityThreshold: 2000,
-          pollInterval: 1000,
+          pollInterval: 100,
         },
       })
       .on('all', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,160 +6,243 @@ import Hyperswarm from 'hyperswarm';
 import Hyperdrive from 'hyperdrive';
 import Localdrive from 'localdrive';
 import Corestore from 'corestore';
-import hypercoreCrypto from 'hypercore-crypto';
 import b4a from 'b4a';
 import chokidar from 'chokidar';
-import { printAsciiArt, parseEnvFile, getDataDir } from './utils.js';
-import { parsePeers } from './peer.js';
+import lodash from 'lodash';
+import { goSync } from '@api3/promise-utils';
+import { printAsciiArt, parseEnvFile, getDataDir, getPeersDir, deriveKeyExchangeTopic } from './utils.js';
+import { checkPeerSizeLimit, parsePeers } from './peer.js';
 import { parseGlobalConfig } from './config.js';
+
+const { debounce } = lodash;
 
 printAsciiArt();
 
 async function main() {
-    const dataDir = getDataDir();
-    const { keyPair } = await parseEnvFile();
-    const globalConfig = parseGlobalConfig();
-    const peersDirectoryPath = path.join(dataDir, 'peers');
-    console.log('Parsing peers...');
-    const initialPeers = await parsePeers(peersDirectoryPath, globalConfig);
-    // Clone initialPeers to be able to add dynamic elements to it
-    const peers = structuredClone(initialPeers);
-    console.log(`Parsed ${initialPeers.length} peers!`);
-    setInterval(async () => {
-        const currentPeers = await parsePeers(peersDirectoryPath, globalConfig);
-        // This assumes parsePeers() returns an object that is fully serializable with toString()
-        if (initialPeers.map(peer => peer.toString()).sort().toString() !== currentPeers.map(peer => peer.toString()).sort().toString()) {
-            console.log('Peers have changed. Exiting to allow restart.');
-            process.exit(0);
-        }
-    }, 60000);
+  const dataDir = getDataDir();
+  const { keyPair } = await parseEnvFile();
+  const globalConfig = parseGlobalConfig();
+  const peersDirectoryPath = getPeersDir(dataDir);
+  console.log('Parsing peers...');
+  const initialPeers = await parsePeers(peersDirectoryPath, globalConfig);
+  // Clone initialPeers to be able to add dynamic elements to it
+  const peers = structuredClone(initialPeers);
+  console.log(`Parsed ${initialPeers.length} peers!`);
+  setInterval(async () => {
+    const currentPeers = await parsePeers(peersDirectoryPath, globalConfig);
+    // This assumes parsePeers() returns an object that is fully serializable with JSON.stringify()
+    if (
+      initialPeers
+        .map((peer) => JSON.stringify(peer))
+        .sort()
+        .toString() !==
+      currentPeers
+        .map((peer) => JSON.stringify(peer))
+        .sort()
+        .toString()
+    ) {
+      console.log('Peers have changed. Exiting to allow restart.');
+      process.exit(0);
+    }
+  }, 60_000);
 
-    console.log('Preparing to connect...');
-    // Create Corestore instances per peer in a local directory
-    const storageDir = path.join(dataDir, '.storage');
-    await Promise.all(peers.map(async (peer) => {
-        if (!peer.disableIncomingReports) {
-            const incomingCorestore = new Corestore(path.join(storageDir, peer.publicKey, 'incoming'));
-            await incomingCorestore.ready();
-            peer.incomingCorestore = incomingCorestore;
-        }
+  console.log('Preparing to connect...');
+  const storageDir = path.join(dataDir, '.storage');
+  const store = new Corestore(storageDir);
+  await store.ready();
 
-        const outgoingCorestore = new Corestore(path.join(storageDir, peer.publicKey, 'outgoing'));
-        await outgoingCorestore.ready();
-        peer.outgoingCorestore = outgoingCorestore;
-    }));
+  // Create a Hyperswarm instance with key pair
+  const swarm = new Hyperswarm({ keyPair });
 
-    // Create a Hyperswarm instance with key pair
-    const swarm = new Hyperswarm({ keyPair });
+  const cleanup = async () => {
+    console.log('Closing swarm...');
+    await swarm.destroy();
+    console.log('Closed swarm.');
+    process.exit(0);
+  };
 
-    const cleanup = async () => {
-        console.log('Closing swarm...');
-        await swarm.destroy();
-        console.log('Closed swarm.');
-        process.exit(0);
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  /*
+   * Partially set up our outgoing hyperdrives so that we can exchange their drive keys with our peers
+   */
+  const peerInfoMap = new Map();
+  await Promise.all(
+    peers.map(async (peer) => {
+      const outgoingNamespace = store.namespace(`outgoing:${peer.publicKey}`);
+      const outgoingHyperdrive = new Hyperdrive(outgoingNamespace);
+      await outgoingHyperdrive.ready();
+
+      console.log(`[${peer.alias}] Outgoing drive key: ${outgoingHyperdrive.key.toString('hex')}`);
+      peerInfoMap.set(peer.publicKey, {
+        ...peer,
+        outgoingHyperdrive,
+        incomingHyperdriveKeyHex: null,
+      });
+    })
+  );
+
+  /*
+   * Establish peer connections
+   */
+  swarm.on('connection', (conn, peerInfo) => {
+    const peerPublicKey = Buffer.from(peerInfo.publicKey).toString('hex');
+    const peer = peerInfoMap.get(peerPublicKey);
+    if (!peer) {
+      console.error(`Unknown peer with public key ${peerPublicKey}`);
+      conn.end();
+      return;
+    }
+
+    const stream = store.replicate(conn);
+    stream.on('error', (err) => handleReplicationError(peer, err));
+    console.log(`Connected to ${peer.alias}!`);
+
+    conn.on('data', (buffer) => handleReceiveDriveKeyFromPeer(peer, buffer));
+    console.log(`Sending drive key to ${peer.alias}`);
+    const message = {
+      type: 'share-drive-key',
+      outgoingHyperdriveKeyHex: peer.outgoingHyperdrive.key.toString('hex'),
     };
+    conn.write(JSON.stringify(message), 'utf8');
+  });
 
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
+  function handleReplicationError(peer, err) {
+    if (err.message.includes('connection reset by peer') || err.message.includes('connection timed out')) {
+      console.log(`${peer.alias} disconnected.`);
+      return;
+    }
+    if (err.message.includes('Duplicate connection')) {
+      console.log(`${peer.alias} connection duplicated.`);
+      return;
+    }
 
-    const handleReplicationError = (peer, streamName, err) => {
-        if (err.message.includes('connection reset by peer') || err.message.includes('connection timed out')) {
-            console.log(`${peer.alias} (${streamName}) disconnected.`);
-            return;
-        }
-        if (err.message.includes('Duplicate connection')) {
-            console.log(`${peer.alias} (${streamName}) connection duplicated.`);
-            return;
-        }
-        const errorMessage = `${peer.alias} (${streamName}) replication error: ${err.message}`;
-        console.error(errorMessage);
-        fs.writeFileSync(path.join(peersDirectoryPath, peer.alias, '.blacklisted'), errorMessage);
-        console.log(`Blacklisted ${peer.alias} due to ${streamName} replication error. Exiting for restart.`);
+    const errorMessage = `${peer.alias} replication error: ${err.message}`;
+    console.error(errorMessage);
+    fs.writeFileSync(path.join(peersDirectoryPath, peer.alias, '.blacklisted'), errorMessage);
+    console.log(`Blacklisted ${peer.alias} due to replication error. Exiting for restart.`);
+    process.exit(0);
+  }
+
+  function handleReceiveDriveKeyFromPeer(peer, buffer) {
+    const result = goSync(() => JSON.parse(buffer.toString('utf8')));
+    if (!result.success) {
+      // We don't log anything because we expect the parsing to fail for all buffers except the key exchange message
+      return;
+    }
+    if (result.data?.type !== 'share-drive-key') {
+      return;
+    }
+
+    console.log(`Received drive key exchange message from ${peer.alias}:`, result.data);
+    if (peer.incomingHyperdriveKeyHex) {
+      // If a peer deletes their .storage directory they will create a new outgoing Hyperdrive the next time their
+      // hinter-core starts up. When that happens it's easier to just restart in order to mirror their new drive.
+      if (peer.incomingHyperdriveKeyHex !== result.data.outgoingHyperdriveKeyHex) {
+        console.log(`${peer.alias} has a new outgoing Hyperdrive. Exiting for restart.`);
         process.exit(0);
-    };
+      }
+      console.log(`[${peer.alias}] Already setup`);
+      return;
+    }
 
-    // On connection with a peer, replicate the respective Corestore instances
-    swarm.on('connection', (conn, peerInfo) => {
-        const peer = peers.find(peer => peer.publicKey === Buffer.from(peerInfo.publicKey).toString('hex'));
-        if (!peer) {
-            conn.end();
-            return;
-        }
-        if (!peer.disableIncomingReports) {
-            const incomingStream = peer.incomingCorestore.replicate(conn);
-            incomingStream.on('error', (err) => handleReplicationError(peer, 'Incoming', err));
-        }
-        const outgoingStream = peer.outgoingCorestore.replicate(conn);
-        outgoingStream.on('error', (err) => handleReplicationError(peer, 'Outgoing', err));
+    peer.incomingHyperdriveKeyHex = result.data.outgoingHyperdriveKeyHex;
+    completeHyperdriveSetup(peer, result.data.outgoingHyperdriveKeyHex);
+  }
 
-        peer.connection = conn;
-        console.log(`Connected to ${peer.alias}!`);
+  /*
+   * We join a key exchange topic first for each peer in order to exchange drive keys with each peer
+   */
+  await Promise.all(
+    peers.map(async (peer) => {
+      const keyExchangeTopic = deriveKeyExchangeTopic(keyPair.publicKey.toString('hex'), peer.publicKey);
+      console.log(`[${peer.alias}] Joining key exchange: ${keyExchangeTopic.toString('hex')}`);
+      const discovery = swarm.join(keyExchangeTopic, { client: true, server: true });
+      await discovery.flushed();
+      console.log(`[${peer.alias}] Joined key exchange`);
+    })
+  );
+
+  async function completeHyperdriveSetup(peer, incomingDriveKeyHex) {
+    console.log(`[${peer.alias}] Setting up drives with incoming drive key: ${incomingDriveKeyHex}`);
+
+    const outgoingDiscovery = swarm.join(peer.outgoingHyperdrive.discoveryKey, { client: false, server: true });
+    await outgoingDiscovery.flushed();
+
+    const outgoingLocaldrive = new Localdrive(path.join(peersDirectoryPath, peer.alias, 'outgoing'));
+    async function mirrorOutgoing() {
+      console.log(`[${peer.alias}] OUT: Mirroring outgoing drive`);
+      const outgoingMirror = outgoingLocaldrive.mirror(peer.outgoingHyperdrive);
+      await outgoingMirror.done();
+      console.log(`[${peer.alias}] OUT: Successfully mirrored outgoing drive`);
+    }
+
+    const deboucedMirrorOutgoing = debounce(mirrorOutgoing, 1000);
+    // Mirror when changes are detected in outgoing localdrive
+    chokidar
+      .watch(path.join(peersDirectoryPath, peer.alias, 'outgoing'), {
+        persistent: true,
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 2000,
+          pollInterval: 1000,
+        },
+      })
+      .on('all', async () => {
+        console.log(`OUT: Detected change in outgoing for ${peer.alias}`);
+        deboucedMirrorOutgoing();
+      });
+
+    await mirrorOutgoing();
+
+    if (peer.disableIncomingReports) {
+      console.log(`[${peer.alias}] Incoming reports are disabled`);
+      return;
+    }
+
+    const incomingNamespace = store.namespace(`incoming:${peer.publicKey}`);
+    const incomingHyperdrive = new Hyperdrive(incomingNamespace, b4a.from(incomingDriveKeyHex, 'hex'));
+    await incomingHyperdrive.ready();
+    const incomingDiscovery = swarm.join(incomingHyperdrive.discoveryKey, { client: true, server: false });
+    await incomingDiscovery.flushed();
+
+    const incomingLocaldrive = new Localdrive(path.join(peersDirectoryPath, peer.alias, 'incoming'));
+    async function mirrorIncoming() {
+      console.log(`[${peer.alias}] IN: Mirroring incoming drive`);
+      const incomingMirror = incomingHyperdrive.mirror(incomingLocaldrive);
+      await incomingMirror.done();
+      console.log(`[${peer.alias}] IN: Successfully mirrored incoming drive`);
+
+      console.log(`[${peer.alias}] Calculating incoming drive size`);
+      const size = await checkPeerSizeLimit(peer, incomingHyperdrive);
+      console.log(`[${peer.alias}] Calculated incoming drive size: ${size / 1024 / 1024}MB (${size})`);
+    }
+
+    const deboucedMirrorIncoming = debounce(mirrorIncoming, 1000);
+    incomingHyperdrive.core.on('append', () => {
+      console.log(`[${peer.alias}] IN: Detected append`);
+      deboucedMirrorIncoming();
     });
+    // Mirror when changes are detected in incoming localdrive
+    chokidar
+      .watch(path.join(peersDirectoryPath, peer.alias, 'incoming'), {
+        persistent: true,
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 2000,
+          pollInterval: 1000,
+        },
+      })
+      .on('all', async () => {
+        console.log(`[${peer.alias}] IN: Detected change in local incoming directory`);
+        await deboucedMirrorIncoming();
+      });
 
-    await Promise.all(peers.map(async (peer) => {
-        if (!peer.disableIncomingReports) {
-            peer.incomingLocaldrive = new Localdrive(path.join(peersDirectoryPath, peer.alias, 'incoming'));
+    deboucedMirrorIncoming();
+  }
 
-            const incomingHyperdriveKeyPair = hypercoreCrypto.keyPair(hypercoreCrypto.data(b4a.concat([b4a.from(peer.publicKey, 'hex'), keyPair.publicKey])));
-            peer.incomingHyperdrive = new Hyperdrive(peer.incomingCorestore, incomingHyperdriveKeyPair.publicKey);
-            await peer.incomingHyperdrive.ready();
-
-            peer.incomingDiscovery = swarm.join(peer.incomingHyperdrive.discoveryKey, { client: true, server: false });
-            await peer.incomingDiscovery.flushed();
-        }
-
-        peer.outgoingLocaldrive = new Localdrive(path.join(peersDirectoryPath, peer.alias, 'outgoing'));
-
-        const outgoingHyperdriveKeyPair = hypercoreCrypto.keyPair(hypercoreCrypto.data(b4a.concat([keyPair.publicKey, b4a.from(peer.publicKey, 'hex')])));
-        const outgoingCorestoreMainHypercore = peer.outgoingCorestore.get({ key: outgoingHyperdriveKeyPair.publicKey, keyPair: outgoingHyperdriveKeyPair })
-        await outgoingCorestoreMainHypercore.ready()
-        peer.outgoingHyperdrive = new Hyperdrive(peer.outgoingCorestore, outgoingHyperdriveKeyPair.publicKey);
-        await peer.outgoingHyperdrive.ready();
-
-        peer.outgoingDiscovery = swarm.join(peer.outgoingHyperdrive.discoveryKey, { client: false, server: true });
-        await peer.outgoingDiscovery.flushed();
-    }));
-    console.log('Ready to connect all peers!');
-
-    await Promise.all(peers.map(async (peer) => {
-        if (!peer.disableIncomingReports) {
-            // Force an initial incoming mirror
-            const initialMirror = peer.incomingHyperdrive.mirror(peer.incomingLocaldrive);
-            await initialMirror.done();
-            // Mirror when changes are detected in incoming hyperdrive
-            (async function watchIncoming() {
-                for await (const { } of peer.incomingHyperdrive.watch()) {
-                    const incomingMirror = peer.incomingHyperdrive.mirror(peer.incomingLocaldrive);
-                    await incomingMirror.done();
-                }
-            })();
-            // Mirror when changes are detected in incoming localdrive
-            chokidar.watch(path.join(peersDirectoryPath, peer.alias, 'incoming'), {
-                persistent: true,
-                ignoreInitial: true,
-                awaitWriteFinish: {
-                    stabilityThreshold: 2000,
-                    pollInterval: 100
-                }
-            }).on('all', async () => {
-                const incomingMirror = peer.incomingHyperdrive.mirror(peer.incomingLocaldrive);
-                await incomingMirror.done();
-            });
-        }
-
-        // Mirror when changes are detected in outgoing localdrive
-        chokidar.watch(path.join(peersDirectoryPath, peer.alias, 'outgoing'), {
-            persistent: true,
-            ignoreInitial: false,
-            awaitWriteFinish: {
-                stabilityThreshold: 2000,
-                pollInterval: 100
-            }
-        }).on('all', async () => {
-            const outgoingMirror = peer.outgoingLocaldrive.mirror(peer.outgoingHyperdrive);
-            await outgoingMirror.done();
-        });
-    }));
+  console.log('Ready to connect all peers!');
 }
 
 main();

--- a/src/peer.js
+++ b/src/peer.js
@@ -1,66 +1,54 @@
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
-import { calculateDirectorySize, getDataDir } from './utils.js';
+import { calculateDriveSize, getPeersDir } from './utils.js';
 import { parsePeerConfig } from './config.js';
 
-function checkPeerSizeLimit(peer) {
-    const storageDir = path.join(getDataDir(), '.storage');
-    const incomingDirectoryPath = path.join(storageDir, peer.publicKey, 'incoming');
-    if (fs.existsSync(incomingDirectoryPath)) {
-        const incomingDirectorySize = calculateDirectorySize(incomingDirectoryPath);
-        if (incomingDirectorySize > peer.peerSizeLimitMB * 1024 * 1024) {
-            return { isBlacklisted: false, exceedsSizeLimit: true };
+export function parsePeers(peersDirectoryPath, globalConfig) {
+  const peers = fs
+    .readdirSync(peersDirectoryPath)
+    .map((peerDirectoryName) => {
+      const peerDirectoryPath = path.join(peersDirectoryPath, peerDirectoryName);
+      // Tolerate files like .DS_STORE
+      if (!fs.statSync(peerDirectoryPath).isDirectory()) {
+        return null;
+      }
+
+      const peer = parsePeerConfig(peerDirectoryPath, globalConfig);
+      peer.alias = path.basename(peerDirectoryPath);
+
+      ['incoming', 'outgoing'].forEach((expectedPeerDirectoryName) => {
+        const expectedPeerDirectoryPath = path.join(peerDirectoryPath, expectedPeerDirectoryName);
+        fs.mkdirSync(expectedPeerDirectoryPath, { recursive: true });
+        // Unlikely, but there may already be files (not directories) named incoming or outgoing in the peer directory
+        if (!fs.statSync(expectedPeerDirectoryPath).isDirectory()) {
+          throw new Error(`${expectedPeerDirectoryPath} is not a directory`);
         }
-    }
-    return { isBlacklisted: false, exceedsSizeLimit: false };
+      });
+
+      if (fs.existsSync(path.join(peerDirectoryPath, '.blacklisted'))) {
+        // Have blacklisted peers be ignored by the .filter(Boolean) below
+        return null;
+      }
+
+      return peer;
+    })
+    .filter(Boolean);
+
+  if (new Set(peers.map((peer) => peer.publicKey)).size !== peers.length) {
+    throw new Error('Duplicate public key found in peer configurations');
+  }
+
+  return peers;
 }
 
-export function parsePeers(peersDirectoryPath, globalConfig) {
-    const peers = fs.readdirSync(peersDirectoryPath).map(peerDirectoryName => {
-        const peerDirectoryPath = path.join(peersDirectoryPath, peerDirectoryName);
-        // Tolerate files like .DS_STORE
-        if (!fs.statSync(peerDirectoryPath).isDirectory()) {
-            return null;
-        }
-
-        const peer = parsePeerConfig(peerDirectoryPath, globalConfig);
-        peer.alias = path.basename(peerDirectoryPath);
-
-        ['incoming', 'outgoing'].forEach(expectedPeerDirectoryName => {
-            const expectedPeerDirectoryPath = path.join(peerDirectoryPath, expectedPeerDirectoryName);
-            fs.mkdirSync(expectedPeerDirectoryPath, { recursive: true });
-            // Unlikely, but there may already be files (not directories) named incoming or outgoing in the peer directory 
-            if (!fs.statSync(expectedPeerDirectoryPath).isDirectory()) {
-                throw new Error(`${expectedPeerDirectoryPath} is not a directory`);
-            }
-        });
-
-        // Saving some compute by not calling checkPeerSizeLimit() on already blacklisted peers
-        if (fs.existsSync(path.join(peerDirectoryPath, '.blacklisted'))) {
-            // Have blacklisted peers be ignored by the .filter(Boolean) below
-            return null;
-        }
-        const sizeCheckResult = checkPeerSizeLimit(peer);
-        if (sizeCheckResult.exceedsSizeLimit) {
-            peer.exceedsSizeLimit = true;
-        }
-        return peer;
-    }).filter(Boolean);
-
-    if (new Set(peers.map(peer => peer.publicKey)).size !== peers.length) {
-        throw new Error('Duplicate public key found in peer configurations');
-    }
-
-    const peersToBlacklist = peers.filter(peer => peer.exceedsSizeLimit);
-    if (peersToBlacklist.length > 0) {
-        const blacklistedAliases = peersToBlacklist.map(peer => {
-            fs.writeFileSync(path.join(peersDirectoryPath, peer.alias, '.blacklisted'), 'Exceeded the size limit');
-            return peer.alias;
-        });
-        console.log(`Peers blacklisted for exceeding the size limit: ${blacklistedAliases.join(', ')}. Exiting for restart.`);
-        process.exit(0);
-    }
-
-    return peers;
+export async function checkPeerSizeLimit(peer, incomingHyperdrive) {
+  const peersDirectoryPath = getPeersDir();
+  const incomingDriveSize = await calculateDriveSize(incomingHyperdrive);
+  if (incomingDriveSize > peer.peerSizeLimitMB * 1024 * 1024) {
+    fs.writeFileSync(path.join(peersDirectoryPath, peer.alias, '.blacklisted'), 'Exceeded the size limit');
+    console.log(`${peer.alias} blacklisted for exceeding the size limit (${incomingDriveSize}). Exiting for restart.`);
+    process.exit(0);
+  }
+  return incomingDriveSize;
 }

--- a/src/peer.js
+++ b/src/peer.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
-import { calculateDriveSize, getPeersDir } from './utils.js';
+import { calculateDriveSize, getPeersDir, logInfo } from './utils.js';
 import { parsePeerConfig } from './config.js';
 
 export function parsePeersAndMonitorForChanges(peersDirectoryPath, globalConfig, callback) {
@@ -71,7 +71,7 @@ export async function checkPeerSizeLimit(peer, incomingHyperdrive) {
   const incomingDriveSize = await calculateDriveSize(incomingHyperdrive);
   if (incomingDriveSize > peer.peerSizeLimitMB * 1024 * 1024) {
     fs.writeFileSync(path.join(getPeersDir(), peer.alias, '.blacklisted'), 'Exceeded the size limit');
-    console.log(`${peer.alias} blacklisted for exceeding the size limit (${incomingDriveSize}). Exiting for restart.`);
+    logInfo(`${peer.alias} blacklisted for exceeding the size limit (${incomingDriveSize}). Exiting for restart.`);
     process.exit(0);
   }
   return incomingDriveSize;

--- a/src/peer.js
+++ b/src/peer.js
@@ -4,6 +4,31 @@ import process from 'process';
 import { calculateDriveSize, getPeersDir } from './utils.js';
 import { parsePeerConfig } from './config.js';
 
+export function parsePeersAndMonitorForChanges(peersDirectoryPath, globalConfig, callback) {
+  const peers = parsePeers(peersDirectoryPath, globalConfig);
+
+  // Clone initialPeers to make sure mutations elsewhere don't affect this check
+  const initialPeers = structuredClone(peers);
+  setInterval(() => {
+    const currentPeers = parsePeers(peersDirectoryPath, globalConfig);
+    // This assumes parsePeers() returns an object that is fully serializable with JSON.stringify()
+    if (
+      initialPeers
+        .map((peer) => JSON.stringify(peer))
+        .sort()
+        .toString() !==
+      currentPeers
+        .map((peer) => JSON.stringify(peer))
+        .sort()
+        .toString()
+    ) {
+      callback();
+    }
+  }, 60_000);
+
+  return peers;
+}
+
 export function parsePeers(peersDirectoryPath, globalConfig) {
   const peers = fs
     .readdirSync(peersDirectoryPath)
@@ -43,10 +68,9 @@ export function parsePeers(peersDirectoryPath, globalConfig) {
 }
 
 export async function checkPeerSizeLimit(peer, incomingHyperdrive) {
-  const peersDirectoryPath = getPeersDir();
   const incomingDriveSize = await calculateDriveSize(incomingHyperdrive);
   if (incomingDriveSize > peer.peerSizeLimitMB * 1024 * 1024) {
-    fs.writeFileSync(path.join(peersDirectoryPath, peer.alias, '.blacklisted'), 'Exceeded the size limit');
+    fs.writeFileSync(path.join(getPeersDir(), peer.alias, '.blacklisted'), 'Exceeded the size limit');
     console.log(`${peer.alias} blacklisted for exceeding the size limit (${incomingDriveSize}). Exiting for restart.`);
     process.exit(0);
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,7 +74,7 @@ export async function parseEnvFile() {
 // Derive a topic from two identities (order-independent)
 export function deriveKeyExchangeTopic(publicKeyA, publicKeyB) {
   const [x, y] = [publicKeyA.toLowerCase(), publicKeyB.toLowerCase()].sort();
-  return crypto.createHash('sha256').update('key-exchange-topic').update(x).update(y).digest();
+  return crypto.createHash('sha256').update('hinter-core/key-exchange-topic').update(x).update(y).digest();
 }
 
 export async function calculateDriveSize(hyperdrive) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -5,63 +6,94 @@ import hypercoreCrypto from 'hypercore-crypto';
 import b4a from 'b4a';
 
 export function getDataDir() {
-    const dataDirIndex = process.argv.indexOf('--data-dir');
-    if (dataDirIndex !== -1 && process.argv.length > dataDirIndex + 1) {
-        const dataDir = process.argv[dataDirIndex + 1];
-        if (!path.isAbsolute(dataDir)) {
-            throw new Error('The --data-dir path must be an absolute path.');
-        }
-        return dataDir;
+  const dataDirIndex = process.argv.indexOf('--data-dir');
+  if (dataDirIndex !== -1 && process.argv.length > dataDirIndex + 1) {
+    const dataDir = process.argv[dataDirIndex + 1];
+    if (!path.isAbsolute(dataDir)) {
+      throw new Error('The --data-dir path must be an absolute path.');
     }
-    return path.join(os.homedir(), 'hinter-core-data');
+    return dataDir;
+  }
+  return path.join(os.homedir(), 'hinter-core-data');
+}
+
+export function getPeersDir(dataDir = getDataDir()) {
+  return path.join(dataDir, 'peers');
 }
 
 export function printAsciiArt() {
-    console.log(
-        '  _     _       _                                     \n',
-        '| |   (_)     | |                                    \n',
-        '| |__  _ _ __ | |_ ___ _ __   ___   ___ ___  _ __ ___ \n',
-        '| \'_ \\| | \'_ \\| __/ _ \\ \'__| |___| / __/ _ \\| \'__/ _ \\\n',
-        '| | | | | | | | ||  __/ |         | (_| (_) | | |  __/\n',
-        '|_| |_|_|_| |_|\\__\\___|_|          \\___\\___/|_|  \\___|\n',
-        '                                                     \n'
-    );
+  console.log(
+    '  _     _       _                                     \n',
+    '| |   (_)     | |                                    \n',
+    '| |__  _ _ __ | |_ ___ _ __   ___   ___ ___  _ __ ___ \n',
+    "| '_ \\| | '_ \\| __/ _ \\ '__| |___| / __/ _ \\| '__/ _ \\\n",
+    '| | | | | | | | ||  __/ |         | (_| (_) | | |  __/\n',
+    '|_| |_|_|_| |_|\\__\\___|_|          \\___\\___/|_|  \\___|\n',
+    '                                                     \n'
+  );
 }
 
 export function calculateDirectorySize(dirPath) {
-    let totalSize = 0;
+  let totalSize = 0;
 
-    function traverse(currentPath) {
-        const items = fs.readdirSync(currentPath);
-        for (const item of items) {
-            const itemPath = path.join(currentPath, item);
-            const stats = fs.statSync(itemPath);
-            if (stats.isDirectory()) {
-                traverse(itemPath);
-            } else {
-                totalSize += stats.size;
-            }
-        }
+  function traverse(currentPath) {
+    const items = fs.readdirSync(currentPath);
+    for (const item of items) {
+      const itemPath = path.join(currentPath, item);
+      const stats = fs.statSync(itemPath);
+      if (stats.isDirectory()) {
+        traverse(itemPath);
+      } else {
+        totalSize += stats.size;
+      }
     }
+  }
 
-    traverse(dirPath);
-    return totalSize;
+  traverse(dirPath);
+  return totalSize;
 }
 
 export async function parseEnvFile() {
-    const dataDir = getDataDir();
-    const envFilePath = path.join(dataDir, '.env');
-    if (!fs.existsSync(envFilePath)) {
-        throw new Error(`${envFilePath} file not found.`);
-    }
-    const envFileContent = fs.readFileSync(envFilePath, 'utf8');
-    const keyPair = {
-        publicKey: b4a.from(envFileContent.match(/PUBLIC_KEY=([0-9a-f]+)/)[1], 'hex'),
-        secretKey: b4a.from(envFileContent.match(/SECRET_KEY=([0-9a-f]+)/)[1], 'hex')
-    };
-    if (!hypercoreCrypto.validateKeyPair(keyPair)) {
-        throw new Error('Key pair not valid');
-    }
+  const dataDir = getDataDir();
+  const envFilePath = path.join(dataDir, '.env');
+  if (!fs.existsSync(envFilePath)) {
+    throw new Error(`${envFilePath} file not found.`);
+  }
+  const envFileContent = fs.readFileSync(envFilePath, 'utf8');
+  const keyPair = {
+    publicKey: b4a.from(envFileContent.match(/PUBLIC_KEY=([0-9a-f]+)/)[1], 'hex'),
+    secretKey: b4a.from(envFileContent.match(/SECRET_KEY=([0-9a-f]+)/)[1], 'hex'),
+  };
+  if (!hypercoreCrypto.validateKeyPair(keyPair)) {
+    throw new Error('Key pair not valid');
+  }
 
-    return { keyPair };
+  return { keyPair };
+}
+
+// Derive a topic from two identities (order-independent)
+export function deriveKeyExchangeTopic(publicKeyA, publicKeyB) {
+  const [x, y] = [publicKeyA.toLowerCase(), publicKeyB.toLowerCase()].sort();
+  return crypto.createHash('sha256').update('key-exchange-topic').update(x).update(y).digest();
+}
+
+export async function calculateDriveSize(hyperdrive) {
+  let total = 0;
+
+  for await (const entry of hyperdrive.db.createHistoryStream()) {
+    if (entry.type !== 'put') continue;
+
+    const hyperblobs = await hyperdrive.getBlobs();
+    const { blob } = entry.value;
+    const downloaded = await hyperblobs.core.has(
+      blob.blockOffset,
+      blob.blockOffset + Math.max(blob.blockLength - 1, 0)
+    );
+    console.log(entry.key, { downloaded, byteLength: blob.byteLength });
+    if (downloaded) {
+      total += blob.byteLength;
+    }
+  }
+
+  return total;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,11 +89,18 @@ export async function calculateDriveSize(hyperdrive) {
       blob.blockOffset,
       blob.blockOffset + Math.max(blob.blockLength - 1, 0)
     );
-    console.log(entry.key, { downloaded, byteLength: blob.byteLength });
     if (downloaded) {
       total += blob.byteLength;
     }
   }
 
   return total;
+}
+
+export function logInfo(message) {
+  console.log('\x1b[2m', new Date().toISOString(), '\x1b[0m', message);
+}
+
+export function logError(message, error) {
+  console.error('\x1b[2m', new Date().toISOString(), '\x1b[0m', message, error);
 }


### PR DESCRIPTION
### What does this change?
- changes the approach to use a single Corestore (in combination with namespaces) in favour of 2 Corestores per peer (using a single store is the recommended approach: https://docs.pears.com/guides/best-practices#use-one-corestore-instance-per-application)
- introduces an outgoing Hyperdive key exchange mechanism (required with a single Corestore approach)
- reworks the peer size limit check to use the incoming Hyperdrive to calculate the size (done after mirroring the incoming Hyperdrive)
- fixes the periodic peer config check (that detects config changes). It wasn't detecting changes because it used `peer.toString()` on the object (which always produces `'[object Object]'`). It now uses `JSON.stringify(peer)`
- reduces the initial flood of mirroring when starting up. The chokidar config was such that it triggered for each file in the outgoing directory
- debounces the calls to mirror drives
- uses the `incomingHyperdrive.core.on('append', () => { ... })` approach to detect changes in the incoming Hyperdrive (used in their docs https://docs.pears.com/how-tos/create-a-full-peer-to-peer-filesystem-with-hyperdrive)
- partially introduces Prettier (I've grown so used to it that I needed it). I will properly set it up in a future PR where I'll format all files and add it to the CI etc 

**NOTE:** The logging is still in "debug mode". E.g. I'm still logging out the drive keys (which we won't want to do in prod)